### PR TITLE
Add AI Rap Guide subpage

### DIFF
--- a/ai-rap-guide.html
+++ b/ai-rap-guide.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Rap Video — Step-by-Step</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Inter', sans-serif;
+    }
+  </style>
+</head>
+<body class="antialiased">
+  <div id="root"></div>
+  <script type="module">
+    import React, { useMemo } from 'https://esm.sh/react@18';
+    import { createRoot } from 'https://esm.sh/react-dom@18/client';
+    import { motion } from 'https://esm.sh/framer-motion@10';
+    import {
+      Music,
+      Mic,
+      FileText,
+      Images,
+      Film,
+      Scissors,
+      Upload,
+      Download,
+      Copy,
+      Wand2,
+      Settings,
+      Timer,
+      Zap,
+      Layers,
+      Rocket,
+      Share2,
+      ShieldCheck,
+    } from 'https://esm.sh/lucide-react@0.438.0';
+
+    const CopyButton = ({ text, label = "Copy" }) => (
+      <button
+        onClick={() => navigator.clipboard.writeText(text)}
+        className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm bg-white/10 hover:bg-white/15 active:bg-white/20 border border-white/10 transition"
+      >
+        <Copy className="w-4 h-4" />
+        <span>{label}</span>
+      </button>
+    );
+
+    const Card = ({ icon: Icon, title, subtitle, children, className = "" }) => (
+      <div className={`relative ${className}`}>
+        <div className="bg-[#0B0F1A]/60 backdrop-blur-xl rounded-2xl border border-white/10 shadow-2xl shadow-black/30">
+          <div className="p-6 md:p-8">
+            {(title || subtitle) && (
+              <div className="flex items-start gap-4 mb-5">
+                {Icon && (
+                  <div className="p-2 rounded-xl bg-white/10 border border-white/10">
+                    <Icon className="w-6 h-6 text-teal-300" />
+                  </div>
+                )}
+                <div>
+                  {title && (
+                    <h3 className="text-xl md:text-2xl font-semibold tracking-tight text-white">
+                      {title}
+                    </h3>
+                  )}
+                  {subtitle && (
+                    <p className="text-sm md:text-base text-slate-300/90 mt-1">{subtitle}</p>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="prose prose-invert max-w-none prose-p:leading-relaxed prose-headings:scroll-mt-24">
+              {children}
+            </div>
+          </div>
+        </div>
+        <div className="absolute -inset-px rounded-2xl pointer-events-none ring-1 ring-white/5" />
+      </div>
+    );
+
+    function AIRapGuide() {
+      const prompts = useMemo(
+        () => ({
+          chatgptMaster: `You are a rap lyricist. Write clean, original Hindi-English (Hinglish) rap lyrics with multisyllabic rhymes, internal rhymes, punchlines, and a memorable hook. Style inspiration: Seedhe Maut, KR$NA (for cadence only—do NOT imitate lyrics or melodies). Constraints:\n- Theme: <your-theme>\n- POV: first-person\n- Structure: [Intro Hook (2 lines)] [Verse 1 (12-16 bars)] [Bridge (4 bars)] [Hook (repeat)] [Verse 2 (12-16 bars)] [Outro]\n- Rhyme density: medium-high\n- Avoid profanity and brand names.\nOutput with section headers and timestamps placeholders like [00:00], [00:12], etc.`,
+          chatgptAlt: `Write 16 bars in Hinglish about <theme>. Keep a tight flow, multisyllabic rhymes, some alliteration. 2 alternate hooks with different cadences. No cuss words.`,
+          sunoPrompt: `Genre: Hindi-English Rap / Trap\nMood: Gritty, confident, energetic\nBPM: 86\nKey: A minor\nVibe refs: modern Indian hip-hop cadence (inspiration only)\nVocal: male rap, crisp consonants, slight saturation, tight doubles on hook\nArrangement: 4-bar intro, Verse (16), Pre (4), Hook (8), Verse2 (16), Hook (8), 4-bar outro.\nMix: punchy kick, snappy snare, sub-bass balanced; master around -14 LUFS.`,
+          storyboardTemplate: `# Storyboard (9:16, 1080x1920)\nStyle: moody, neon accents, handheld + dolly mix, natural grain\n\nT00:00–00:04 — Cold open close-up on hands tapping a table to the beat; shallow depth; 35mm.\nT00:04–00:12 — Hook v1: slow push-in on silhouette against city lights; light rain bokeh; 85mm.\nT00:12–00:24 — Verse: alley walk, parallax dolly left; neon sign flickers; 24mm.\nT00:24–00:36 — Verse: rooftop wide, skyline; wind hits jacket; 18mm.\nT00:36–00:44 — Bridge: profile shot + lens flare; 50mm.\nT00:44–00:52 — Hook v2: crowd cutaways, slow shutter drag; 35mm.\nT00:52–01:04 — Verse2: mirror reflection, whip pan; 35mm.\nT01:04–01:12 — Verse2: stairs descent, overhead top shot; 16mm.\nT01:12–01:20 — Final hook: confetti dust motes in beam light; 85mm.\nNotes: keep subject outfit consistent; add beat markers at bar starts.`,
+          veoPrompt: `Generate a 4–8s vertical clip (9:16) of <scene> with <subject>. Camera: <camera move>. Lens: <focal length>. Motion: natural handheld micro-shake. Lighting: practical neon + soft fill. Color: cinematic teal/magenta. Texture: slight film grain. Mood: gritty hopeful. Ensure lip-sync OFF; pace visuals with beat only.`,
+          midjourneyPreset1: `Cinematic close-up portrait of Indian rapper in moody neon alley, raindrops bokeh, shallow depth of field, 50mm lens, realistic skin texture, top-down soft fill, gritty urban palette, volumetric haze, 9:16, --ar 9:16 --v 6 --style raw`,
+          midjourneyPreset2: `Wide rooftop shot overlooking city skyline at dusk, wind moving jacket, cinematic composition, 24mm lens feel, natural grain, 9:16 --ar 9:16 --v 6 --style raw`,
+          editChecklist: `\n• Create beat markers on downbeats or every 4 bars\n• Place hooks on strongest visuals\n• Alternate motion: push-in → lateral → static → whip\n• Add whooshes only where motion justifies\n• Maintain one outfit/character continuity\n• Loudness target: -14 to -16 LUFS (streaming)\n• Export H.264, 1080×1920, 23.976 or 30 fps, high bitrate`,
+        }),
+        []
+      );
+
+      return (
+        <div className="min-h-screen bg-black text-slate-100 relative">
+          {/* ===== BACKGROUND ===== */}
+          <div className="fixed inset-0 z-0 overflow-hidden">
+            <div className="absolute inset-0 bg-black animated-gradient"></div>
+            <div
+              className="absolute inset-0 opacity-20"
+              style={{
+                backgroundImage: "url(https://www.transparenttextures.com/patterns/grain.png)",
+                mixBlendMode: "overlay",
+              }}
+            ></div>
+          </div>
+
+          <style>{`
+            .animated-gradient {
+              background: radial-gradient(circle at 10% 20%, rgba(128, 0, 128, 0.4), transparent 50%),
+                          radial-gradient(circle at 80% 90%, rgba(0, 0, 255, 0.4), transparent 50%),
+                          radial-gradient(circle at 50% 50%, rgba(255, 25, 25, 0.3), transparent 50%);
+              background-size: 250% 250%;
+              animation: moveGradient 25s ease infinite;
+            }
+            @keyframes moveGradient {
+              0% { background-position: 0% 50%; }
+              50% { background-position: 100% 50%; }
+              100% { background-position: 0% 50%; }
+            }
+          `}</style>
+
+          {/* ===== PAGE CONTENT ===== */}
+          <header className="relative z-10">
+            <div className="sticky top-0 z-20 backdrop-blur-xl bg-black/40 border-b border-white/10">
+              <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-teal-400/80 to-purple-400/80 border border-white/20"></div>
+                  <span className="font-semibold tracking-wide">AI Rap Video — Step‑by‑Step</span>
+                </div>
+                <nav className="hidden md:flex items-center gap-5 text-sm text-slate-300">
+                  <a href="#overview" className="hover:text-white">Overview</a>
+                  <a href="#steps" className="hover:text-white">Steps</a>
+                  <a href="#prompts" className="hover:text-white">Prompts</a>
+                  <a href="#faq" className="hover:text-white">FAQ</a>
+                </nav>
+              </div>
+            </div>
+
+            <div className="mx-auto max-w-6xl px-4 py-14 md:py-20">
+              <motion.div
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6 }}
+                className="relative z-10"
+              >
+                <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 border border-white/10 text-sm text-slate-200 mb-5">
+                  <Wand2 className="w-4 h-4" />
+                  <span>Real workflow: ChatGPT → Suno → Storyboard → Veo 3 / Midjourney → Edit</span>
+                </div>
+                <h1 className="text-3xl md:text-5xl font-extrabold leading-tight tracking-tight text-white">
+                  Make a Rap Music Video with AI —
+                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-teal-300 via-cyan-300 to-purple-300"> end‑to‑end in minutes</span>
+                </h1>
+                <p className="mt-4 max-w-3xl text-slate-300 text-base md:text-lg">
+                  This guide turns one simple process into a repeatable system for your Instagram: write lyrics with ChatGPT, generate the track in Suno, storyboard from the lyrics, then create visuals with Veo 3 and Midjourney. Edit, export, post. Done.
+                </p>
+                <div className="mt-6 flex flex-wrap gap-3">
+                  <a href="#prompts" className="rounded-xl bg-teal-500/20 hover:bg-teal-500/30 border border-teal-300/30 text-teal-200 px-4 py-2 text-sm">Jump to Prompts</a>
+                  <a href="#steps" className="rounded-xl bg-white/10 hover:bg-white/15 border border-white/10 text-slate-100 px-4 py-2 text-sm">See the Steps</a>
+                </div>
+              </motion.div>
+            </div>
+          </header>
+
+          <main className="relative z-10 pb-20">
+            {/* Overview */}
+            <section id="overview" className="mx-auto max-w-6xl px-4 grid md:grid-cols-3 gap-6 md:gap-8">
+              <Card icon={Music} title="Tools" subtitle="What you’ll use">
+                <ul className="space-y-2 text-sm">
+                  <li>• ChatGPT — original Hinglish rap lyrics</li>
+                  <li>• Suno — AI music generation (rap/trap)</li>
+                  <li>• Storyboard — shot list synced to bars</li>
+                  <li>• Veo 3 — short video clips (9:16)</li>
+                  <li>• Midjourney — cinematic stills for cutaways</li>
+                  <li>• Editor — CapCut / Premiere / Resolve</li>
+                </ul>
+              </Card>
+              <Card icon={ShieldCheck} title="Ethics & Safety" subtitle="Create, don’t imitate">
+                <p className="text-sm">
+                  Use artists only as <em>style inspiration</em>. Don’t copy lyrics, melodies, or vocals. Check the terms of any AI tool you publish with. Keep your content original and respectful.
+                </p>
+              </Card>
+              <Card icon={Rocket} title="Output" subtitle="What you’ll get">
+                <ul className="space-y-2 text-sm">
+                  <li>• 60–90s vertical video (1080×1920)</li>
+                  <li>• Catchy hook + coherent verses</li>
+                  <li>• Gritty urban visuals with continuity</li>
+                  <li>• Export loudness around −14 to −16 LUFS</li>
+                </ul>
+              </Card>
+            </section>
+
+            {/* Steps */}
+            <section id="steps" className="mx-auto max-w-6xl px-4 mt-12 md:mt-16 space-y-8">
+              <Card icon={Mic} title="Step 1 — Write lyrics with ChatGPT" subtitle="Give clear boundaries and a theme">
+                <p>
+                  Feed context (theme, POV, structure, language mix). Ask for bar counts, timestamps, and 2–3 alternate hooks. Keep it clean if you’re posting on Instagram.
+                </p>
+                <div className="mt-4 p-4 rounded-xl bg-black/40 border border-white/10">
+                  <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.chatgptMaster}</pre>
+                  <div className="mt-3"><CopyButton text={prompts.chatgptMaster} label="Copy ChatGPT Master Prompt" /></div>
+                </div>
+                <p className="mt-4 text-sm text-slate-300">Bonus: Ask ChatGPT to highlight <strong>visual nouns</strong> and <strong>verbs</strong> to guide your storyboard.</p>
+              </Card>
+
+              <Card icon={Music} title="Step 2 — Generate the track in Suno" subtitle="Lock the vibe: BPM, key, mood">
+                <p>
+                  Paste your final lyrics in Suno, select a rap/trap style, and use a concise system prompt for mix and arrangement. Iterate 2–3 times to nail the hook.
+                </p>
+                <div className="mt-4 p-4 rounded-xl bg-black/40 border border-white/10">
+                  <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.sunoPrompt}</pre>
+                  <div className="mt-3"><CopyButton text={prompts.sunoPrompt} label="Copy Suno Prompt" /></div>
+                </div>
+                <ul className="mt-4 text-sm space-y-2">
+                  <li>• Keep the <strong>BPM</strong> consistent with the flow you wrote.</li>
+                  <li>• If the hook lacks impact, shorten lines and add doubles (tight layer).</li>
+                  <li>• Render 2–4 takes; pick the tightest delivery and hook.</li>
+                </ul>
+              </Card>
+
+              <Card icon={FileText} title="Step 3 — Build a storyboard from lyrics" subtitle="Map bars to shots">
+                <p>
+                  Turn timestamps/sections into a visual plan. Vary camera movement (push, lateral, static, whip) and keep one outfit for continuity.
+                </p>
+                <div className="mt-4 p-4 rounded-xl bg-black/40 border border-white/10">
+                  <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.storyboardTemplate}</pre>
+                  <div className="mt-3"><CopyButton text={prompts.storyboardTemplate} label="Copy Storyboard Template" /></div>
+                </div>
+              </Card>
+
+              <Card icon={Film} title="Step 4 — Generate visuals (Veo 3 & Midjourney)" subtitle="Short clips + cinematic stills">
+                <h4 className="text-lg font-semibold mb-2">Veo 3 (video clips)</h4>
+                <p>Use 4–8 second clips per beat section. Avoid lip-sync; let visuals ride the rhythm.</p>
+                <div className="mt-3 p-4 rounded-xl bg-black/40 border border-white/10">
+                  <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.veoPrompt}</pre>
+                  <div className="mt-3"><CopyButton text={prompts.veoPrompt} label="Copy Veo 3 Prompt" /></div>
+                </div>
+                <h4 className="text-lg font-semibold mt-6 mb-2">Midjourney (stills / cutaways)</h4>
+                <p>Keep character, outfit, and palette consistent across images. Use 9:16 and a realistic style.</p>
+                <div className="grid md:grid-cols-2 gap-3 mt-3">
+                  <div className="p-4 rounded-xl bg-black/40 border border-white/10">
+                    <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.midjourneyPreset1}</pre>
+                    <div className="mt-3"><CopyButton text={prompts.midjourneyPreset1} label="Copy MJ Preset — Portrait" /></div>
+                  </div>
+                  <div className="p-4 rounded-xl bg-black/40 border border-white/10">
+                    <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.midjourneyPreset2}</pre>
+                    <div className="mt-3"><CopyButton text={prompts.midjourneyPreset2} label="Copy MJ Preset — Rooftop" /></div>
+                  </div>
+                </div>
+                <ul className="mt-4 text-sm space-y-2">
+                  <li>• Color: teal/magenta works great on neon nights; keep skintones natural.</li>
+                  <li>• Lens language: alternate 18–24mm wides with 50–85mm portraits.</li>
+                  <li>• Add subtle grain for cohesion between video and stills.</li>
+                </ul>
+              </Card>
+
+              <Card icon={Scissors} title="Step 5 — Edit & sync" subtitle="CapCut / Premiere / Resolve">
+                <ul className="text-sm space-y-2">
+                  <li>1) Drop the Suno track; set sequence to 1080×1920 (9:16), 23.976 or 30 fps.</li>
+                  <li>2) Create beat markers at downbeats (every 4 bars). <span className="text-slate-400">Place hook hits on your flashiest shots.</span></li>
+                  <li>3) Cut to the beat: push-in → lateral → static → whip; avoid repetitive motion.</li>
+                  <li>4) Layer a mild film grain and a unified LUT. Keep contrast moderate for Reels.</li>
+                  <li>5) Add tasteful motion blur/optical flow on fast whips only.</li>
+                  <li>6) Titles: minimal, high-contrast; avoid covering the subject’s face.</li>
+                </ul>
+                <div className="mt-4 p-4 rounded-xl bg-black/40 border border-white/10">
+                  <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.editChecklist}</pre>
+                  <div className="mt-3"><CopyButton text={prompts.editChecklist} label="Copy Edit Checklist" /></div>
+                </div>
+              </Card>
+
+              <Card icon={Upload} title="Step 6 — Export & post" subtitle="Settings that won’t get you flagged">
+                <ul className="text-sm space-y-2">
+                  <li>• Codec: H.264, High profile, CBR or VBR 2‑pass high bitrate.</li>
+                  <li>• Resolution/AR: 1080×1920 (9:16). FPS: 23.976 or 30.</li>
+                  <li>• Audio loudness: target −14 to −16 LUFS (streams), true peak ≤ −1 dB.</li>
+                  <li>• Cover: pick your strongest portrait frame; add a tiny title if needed.</li>
+                  <li>• Caption: mention tools + vibe + credits. Use niche hashtags, not spam.</li>
+                </ul>
+              </Card>
+            </section>
+
+            {/* Prompt Library */}
+            <section id="prompts" className="mx-auto max-w-6xl px-4 mt-12 md:mt-16 space-y-6">
+              <h2 className="text-2xl md:text-3xl font-bold">Prompt Library</h2>
+              <div className="grid md:grid-cols-2 gap-6">
+                <Card icon={Wand2} title="ChatGPT Lyric Master" subtitle="Clean Hinglish, strong hook">
+                  <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.chatgptMaster}</pre>
+                  <div className="mt-3"><CopyButton text={prompts.chatgptMaster} /></div>
+                </Card>
+                <Card icon={Wand2} title="ChatGPT Quick 16" subtitle="One-verse speed prompt">
+                  <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.chatgptAlt}</pre>
+                  <div className="mt-3"><CopyButton text={prompts.chatgptAlt} /></div>
+                </Card>
+                <Card icon={Music} title="Suno Track Spec" subtitle="Genre, BPM, mix notes">
+                  <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.sunoPrompt}</pre>
+                  <div className="mt-3"><CopyButton text={prompts.sunoPrompt} /></div>
+                </Card>
+                <Card icon={Film} title="Veo 3 Shot Prompt" subtitle="Short vertical clips">
+                  <pre className="text-xs md:text-sm whitespace-pre-wrap leading-relaxed">{prompts.veoPrompt}</pre>
+                  <div className="mt-3"><CopyButton text={prompts.veoPrompt} /></div>
+                </Card>
+              </div>
+            </section>
+
+            {/* FAQ */}
+            <section id="faq" className="mx-auto max-w-6xl px-4 mt-12 md:mt-16">
+              <Card title="FAQ" icon={Settings} subtitle="Quick answers for common issues">
+                <div className="grid md:grid-cols-2 gap-6 text-sm">
+                  <div>
+                    <h4 className="font-semibold text-white">Suno keeps changing my flow?</h4>
+                    <p className="text-slate-300 mt-1">Shorten lines, specify BPM, and ask for fewer ad‑libs. Generate 2–4 takes and pick the tightest.</p>
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-white">My visuals don’t match between shots.</h4>
+                    <p className="text-slate-300 mt-1">Lock outfit, color palette, and lens language. Reuse the same subject description across prompts.</p>
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-white">The edit feels flat.</h4>
+                    <p className="text-slate-300 mt-1">Alternate movement patterns and reserve your best shots for the hook. Add beat markers and vary focal lengths.</p>
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-white">Will Instagram flag AI music?</h4>
+                    <p className="text-slate-300 mt-1">Stick to original lyrics and melodies. Review each tool’s publishing terms and add clear credits in your caption.</p>
+                  </div>
+                </div>
+              </Card>
+            </section>
+
+            {/* Footer */}
+            <footer className="mx-auto max-w-6xl px-4 mt-12 md:mt-20">
+              <div className="text-xs text-slate-400/80 pb-16">
+                Built with ❤️ for creators. This page is a learning resource; always follow the terms of the tools you use.
+              </div>
+            </footer>
+          </main>
+        </div>
+      );
+    }
+
+    const root = createRoot(document.getElementById('root'));
+    root.render(<AIRapGuide />);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -128,9 +128,12 @@
                 <img src="Logo.png" alt="Social SEO Logo" class="h-8 w-8 object-contain">
                 <span class="font-bold text-xl text-white">Social SEO</span>
             </div>
-            <a href="#content-plan" class="btn-primary text-white font-semibold py-2 px-5 rounded-lg text-sm">
-                See The Plan
-            </a>
+            <div class="flex items-center space-x-4">
+                <a href="ai-rap-guide.html" class="text-gray-300 hover:text-white text-sm">AI Rap Guide</a>
+                <a href="#content-plan" class="btn-primary text-white font-semibold py-2 px-5 rounded-lg text-sm">
+                    See The Plan
+                </a>
+            </div>
         </nav>
     </header>
 


### PR DESCRIPTION
## Summary
- add AI Rap Guide page with interactive copy buttons and full workflow instructions
- link the new page from the site header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc46969c44832b872f1e29fdb7f843