### PR TITLE
fix: guard external assets

### DIFF
--- a/guide2/index.html
+++ b/guide2/index.html
@@ -14,12 +14,39 @@
 <body class="min-h-screen bg-black text-slate-100">
   <div id="root"></div>
   <script type="text/babel">
-    const { motion } = window.framerMotion;
-    const { Music, Mic, FileText, Images, Film, Scissors, Upload, Download, Copy, Wand2, Settings, Timer, Zap, Layers, Rocket, Share2, ShieldCheck } = window.lucideReact;
+    // Safely access external libraries that may fail to load when the page is
+    // served without an internet connection. Fallbacks prevent runtime errors
+    // like "Cannot read properties of undefined (reading 'map')" when
+    // destructuring from an unavailable object.
+    const motion = window.framerMotion?.motion || {
+      div: ({ children, ...props }) => <div {...props}>{children}</div>
+    };
+    const {
+      Music,
+      Mic,
+      FileText,
+      Images,
+      Film,
+      Scissors,
+      Upload,
+      Download,
+      Copy,
+      Wand2,
+      Settings,
+      Timer,
+      Zap,
+      Layers,
+      Rocket,
+      Share2,
+      ShieldCheck
+    } = window.lucideReact || {};
 
     const CopyButton = ({ text, label = "Copy" }) => (
-      <button onClick={() => navigator.clipboard.writeText(text)} className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm bg-white/10 hover:bg-white/15 active:bg-white/20 border border-white/10 transition">
-        <Copy className="w-4 h-4" />
+      <button
+        onClick={() => navigator.clipboard?.writeText(text)}
+        className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm bg-white/10 hover:bg-white/15 active:bg-white/20 border border-white/10 transition"
+      >
+        {Copy && <Copy className="w-4 h-4" />}
         <span>{label}</span>
       </button>
     );


### PR DESCRIPTION
## Summary
- avoid runtime crashes when `framer-motion` or `lucide-react` scripts fail to load
- use safe clipboard and icon handling in `CopyButton`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd8c9d560832b88740b622e8c6028