### PR TITLE
fix: guard external assets

### DIFF
--- a/guide2/index.html
+++ b/guide2/index.html
@@ -14,12 +14,39 @@
 <body class="min-h-screen bg-black text-slate-100">
   <div id="root"></div>
   <script type="text/babel">
-    const { motion } = window.framerMotion;
-    const { Music, Mic, FileText, Images, Film, Scissors, Upload, Download, Copy, Wand2, Settings, Timer, Zap, Layers, Rocket, Share2, ShieldCheck } = window.lucideReact;
+    // Safely access external libraries that may fail to load when the page is
+    // served without an internet connection. Fallbacks prevent runtime errors
+    // like "Cannot read properties of undefined (reading 'map')" when
+    // destructuring from an unavailable object.
+    const motion = window.framerMotion?.motion || {
+      div: ({ children, ...props }) => <div {...props}>{children}</div>
+    };
+    const {
+      Music,
+      Mic,
+      FileText,
+      Images,
+      Film,
+      Scissors,
+      Upload,
+      Download,
+      Copy,
+      Wand2,
+      Settings,
+      Timer,
+      Zap,
+      Layers,
+      Rocket,
+      Share2,
+      ShieldCheck
+    } = window.lucideReact || {};
 
     const CopyButton = ({ text, label = "Copy" }) => (
-      <button onClick={() => navigator.clipboard.writeText(text)} className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm bg-white/10 hover:bg-white/15 active:bg-white/20 border border-white/10 transition">
-        <Copy className="w-4 h-4" />
+      <button
+        onClick={() => navigator.clipboard?.writeText(text)}
+        className="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm bg-white/10 hover:bg-white/15 active:bg-white/20 border border-white/10 transition"
+      >
+        {Copy && <Copy className="w-4 h-4" />}
         <span>{label}</span>
       </button>
     );
@@ -102,7 +129,7 @@
             <div className="mx-auto max-w-6xl px-4 py-14 md:py-20">
               <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6 }} className="relative z-10">
                 <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 border border-white/10 text-sm text-slate-200 mb-5">
-                  <Wand2 className="w-4 h-4" />
+                  {Wand2 && <Wand2 className="w-4 h-4" />}
                   <span>Real workflow: ChatGPT → Suno → Storyboard → Veo 3 / Midjourney → Edit</span>
                 </div>
                 <h1 className="text-3xl md:text-5xl font-extrabold leading-tight tracking-tight text-white">


### PR DESCRIPTION
## Summary
- avoid runtime crashes when `framer-motion` or `lucide-react` scripts fail to load
- use safe clipboard and icon handling in `CopyButton`
- guard standalone `Wand2` icon to prevent undefined component errors

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Guide-instagram/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bdd8c9d560832b88740b622e8c6028