### PR TITLE
Add Avatar Guide onboarding subpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Static guides for creating and sharing content on Instagram.
 
 - [Your Next 10 Days of Evergreen Content](index.html)
 - [AI Rap Video — Step‑by‑Step](guide2/index.html)
+- [Avatar Studio Onboarding Guide](avatar-guide/index.html)

--- a/avatar-guide/index.html
+++ b/avatar-guide/index.html
@@ -1,0 +1,668 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Avatar Studio Onboarding</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body class="bg-black text-white">
+    <div id="root"></div>
+    <script type="text/babel">
+      const { useState, useRef, useEffect } = React;
+
+      const GlassPanel = ({ children, className = "" }) => (
+        <div className={`backdrop-blur-sm bg-black/30 border border-white/10 shadow-lg rounded-2xl p-6 md:p-10 ${className}`}>
+          {children}
+        </div>
+      );
+
+      const DoDontCard = ({ type, title, items }) => {
+        const isDo = type === "do";
+        const color = isDo ? "text-green-400" : "text-red-400";
+        const borderColor = isDo ? "border-green-400" : "border-red-400";
+        const icon = isDo ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+              clipRule="evenodd"
+            />
+          </svg>
+        ) : (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+              clipRule="evenodd"
+            />
+          </svg>
+        );
+
+        return (
+          <GlassPanel
+            className={`flex flex-col items-start space-y-3 p-4 border ${borderColor}`}
+          >
+            <div className="flex items-center space-x-2">
+              <div className={color}>{icon}</div>
+              <h3 className={`text-xl font-semibold ${color}`}>{title}</h3>
+            </div>
+            <ul className="text-sm space-y-2">
+              {items.map((item, index) => (
+                <li key={index}>{item}</li>
+              ))}
+            </ul>
+          </GlassPanel>
+        );
+      };
+
+      const ChecklistItem = ({ title, time, icon, isChecked, onToggle }) => (
+        <GlassPanel
+          onClick={onToggle}
+          className={`flex flex-col items-center space-y-2 text-center cursor-pointer transition-transform hover:scale-105 duration-200 ${
+            isChecked ? "border-green-400" : "border-white/10"
+          }`}
+        >
+          <div className="relative text-4xl text-cyan-300 mb-2">
+            {icon}
+            {isChecked && (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-6 w-6 text-green-400 absolute bottom-0 right-0 transform translate-x-1/2 translate-y-1/2"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            )}
+          </div>
+          <h3 className="text-xl font-bold">{title}</h3>
+          <span className="text-sm text-white/70">{time}</span>
+        </GlassPanel>
+      );
+
+      const FolderChecklistItem = ({ folderName, isChecked, onToggle }) => (
+        <li
+          onClick={onToggle}
+          className={`flex items-center space-x-3 cursor-pointer p-4 rounded-lg transition-colors duration-200 ${
+            isChecked ? "bg-green-600/20 text-green-400" : "bg-white/5 hover:bg-white/10"
+          }`}
+        >
+          <div
+            className={`w-6 h-6 flex-shrink-0 flex items-center justify-center rounded-full transition-colors duration-200 ${
+              isChecked ? "bg-green-400 text-black" : "bg-white/20"
+            }`}
+          >
+            {isChecked ? (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            ) : (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4 text-white/50"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            )}
+          </div>
+          <span className="font-mono text-white/80">{folderName}</span>
+        </li>
+      );
+
+      const Chatbot = ({ setIsOpen }) => {
+        const [messages, setMessages] = useState([
+          {
+            sender: "bot",
+            text: "Hello! I am your AI assistant for this onboarding page. How can I help you today?"
+          }
+        ]);
+        const [input, setInput] = useState("");
+        const [isTyping, setIsTyping] = useState(false);
+        const messagesEndRef = useRef(null);
+
+        const systemPrompt = `You are a helpful onboarding assistant for an AI avatar creation service. Your purpose is to answer user questions about the content of this specific onboarding page, such as file formats, recording tips, or folder structure. Be concise and supportive. Do not mention API keys or technical terms not found on the page. Do not act as a traditional chatbot; simply answer questions based on the provided guide.`;
+
+        const handleSendMessage = async () => {
+          if (input.trim() === "") return;
+          const userMessage = { sender: "user", text: input };
+          setMessages((prev) => [...prev, userMessage]);
+          setInput("");
+          setIsTyping(true);
+
+          const prompt = `Based on the provided guide, answer the user's question. The question is: "${input}"`;
+
+          try {
+            const apiKey = "";
+            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`;
+
+            const payload = {
+              contents: [{ role: "user", parts: [{ text: prompt }] }],
+              systemInstruction: {
+                parts: [{ text: systemPrompt }]
+              }
+            };
+
+            const response = await fetch(apiUrl, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload)
+            });
+
+            const result = await response.json();
+            const botMessage = result?.candidates?.[0]?.content?.parts?.[0]?.text;
+
+            if (botMessage) {
+              setMessages((prev) => [...prev, { sender: "bot", text: botMessage }]);
+            } else {
+              setMessages((prev) => [
+                ...prev,
+                {
+                  sender: "bot",
+                  text: "Sorry, I am having trouble connecting right now. Please try again later."
+                }
+              ]);
+            }
+          } catch (error) {
+            console.error("Error fetching from Gemini API:", error);
+            setMessages((prev) => [
+              ...prev,
+              {
+                sender: "bot",
+                text: "Sorry, I am having trouble connecting right now. Please try again later."
+              }
+            ]);
+          } finally {
+            setIsTyping(false);
+          }
+        };
+
+        useEffect(() => {
+          messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+        }, [messages]);
+
+        return (
+          <div className="fixed bottom-20 right-6 w-full max-w-sm h-[60vh] z-[99]">
+            <GlassPanel className="h-full flex flex-col p-4">
+              <div className="flex justify-between items-center pb-4 border-b border-white/10">
+                <h3 className="font-bold text-lg">AI Assistant</h3>
+                <button
+                  onClick={() => setIsOpen(false)}
+                  className="text-white/70 hover:text-white transition-colors duration-200"
+                  aria-label="Close chat"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-6 w-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <div className="flex-1 overflow-y-auto my-4 space-y-4">
+                {messages.map((msg, index) => (
+                  <div
+                    key={index}
+                    className={`flex ${
+                      msg.sender === "user" ? "justify-end" : "justify-start"
+                    }`}
+                  >
+                    <div
+                      className={`p-3 rounded-xl max-w-[80%] ${
+                        msg.sender === "user"
+                          ? "bg-blue-500/80 text-white"
+                          : "bg-gray-700/80 text-white"
+                      }`}
+                    >
+                      {msg.text}
+                    </div>
+                  </div>
+                ))}
+                {isTyping && (
+                  <div className="flex justify-start">
+                    <div className="p-3 rounded-xl bg-gray-700/80 text-white">...</div>
+                  </div>
+                )}
+                <div ref={messagesEndRef} />
+              </div>
+              <div className="flex space-x-2">
+                <input
+                  type="text"
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSendMessage();
+                  }}
+                  className="flex-1 p-3 rounded-lg bg-white/10 border border-white/10 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                  placeholder="Ask a question..."
+                  disabled={isTyping}
+                />
+                <button
+                  onClick={handleSendMessage}
+                  className="bg-cyan-500 hover:bg-cyan-600 text-white p-3 rounded-lg disabled:bg-gray-500"
+                  disabled={isTyping}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-6 w-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                  </svg>
+                </button>
+              </div>
+            </GlassPanel>
+          </div>
+        );
+      };
+
+      const App = () => {
+        const [checklist, setChecklist] = useState({
+          video: false,
+          voice: false,
+          consent: false,
+          brand: false,
+          pronunciation: false,
+          portraits: false
+        });
+
+        const [folderChecklist, setFolderChecklist] = useState({
+          consent: false,
+          videoMaster: false,
+          voiceClips: false,
+          portraits: false,
+          brandKit: false,
+          pronunciations: false
+        });
+
+        const allItemsChecked = Object.values(checklist).every(Boolean);
+        const allFoldersChecked = Object.values(folderChecklist).every(Boolean);
+
+        const toggleChecklist = (item) => {
+          setChecklist((prev) => ({ ...prev, [item]: !prev[item] }));
+        };
+
+        const toggleFolderChecklist = (item) => {
+          setFolderChecklist((prev) => ({ ...prev, [item]: !prev[item] }));
+        };
+
+        const [isChatbotOpen, setIsChatbotOpen] = useState(false);
+
+        const scrollToChecklist = () => {
+          const target = document.getElementById("quick-start");
+          if (target) {
+            window.scrollTo({
+              top: target.offsetTop,
+              behavior: "smooth"
+            });
+          }
+        };
+
+        return (
+          <div className="min-h-screen bg-gradient-to-br from-indigo-900 to-red-900 text-white font-sans relative">
+            <header className="fixed top-0 left-0 right-0 z-50 p-6 flex justify-between items-center backdrop-blur-sm bg-black/10">
+              <div className="flex items-center space-x-2">
+                <span className="text-xl font-bold">Avatar Studio</span>
+              </div>
+              <a
+                href="https://wa.me/919315858737?text=Hi%2C%20I%20have%20a%20question%20about%20my%20AI%20avatar%20onboarding."
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-white/70 hover:text-white transition-colors"
+              >
+                Support
+              </a>
+            </header>
+
+            <button
+              onClick={() => setIsChatbotOpen((open) => !open)}
+              className="fixed bottom-6 right-6 z-[100] bg-cyan-500 hover:bg-cyan-600 text-white p-4 rounded-full shadow-lg transition-transform duration-300 transform hover:scale-110"
+              aria-label="Open chat"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+                />
+              </svg>
+            </button>
+
+            {isChatbotOpen && <Chatbot setIsOpen={setIsChatbotOpen} />}
+
+            <main className="relative z-10 container mx-auto px-4 md:px-8 py-20 space-y-20">
+              <section className="text-center space-y-6 pt-16">
+                <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold leading-tight">
+                  You’re Ready. Let’s Capture Your Avatar.
+                </h1>
+                <p className="text-lg text-white/80 max-w-2xl mx-auto">
+                  This quick guide helps you record once—and get it right. Follow the steps below to submit your best-quality footage, audio, and brand assets.
+                </p>
+                <div className="flex flex-col sm:flex-row justify-center items-center space-y-4 sm:space-y-0 sm:space-x-4 mt-8">
+                  <button
+                    onClick={scrollToChecklist}
+                    className="bg-white/10 backdrop-blur-sm border border-white/20 text-white font-bold py-3 px-8 rounded-full hover:bg-white/20 transition-colors duration-300 shadow-xl"
+                  >
+                    Start Checklist
+                  </button>
+                </div>
+              </section>
+
+              <section id="quick-start" className="space-y-6">
+                <h2 className="text-3xl font-bold text-center">Quick Start</h2>
+                <GlassPanel className="text-center">
+                  <p className="text-white/80 mb-6">
+                    You'll record: one ~5-minute talking-head video, 6–10 short natural voice clips, and two short consent statements. You'll upload: brand kit, pronunciation list, and 1–2 portraits.
+                  </p>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                    <ChecklistItem
+                      title="Talking-Head Video"
+                      time="~5 minutes"
+                      icon="🎬"
+                      isChecked={checklist.video}
+                      onToggle={() => toggleChecklist("video")}
+                    />
+                    <ChecklistItem
+                      title="Voice Clips"
+                      time="6–10 clips"
+                      icon="🎙️"
+                      isChecked={checklist.voice}
+                      onToggle={() => toggleChecklist("voice")}
+                    />
+                    <ChecklistItem
+                      title="Consent Statements"
+                      time="2 short clips"
+                      icon="📝"
+                      isChecked={checklist.consent}
+                      onToggle={() => toggleChecklist("consent")}
+                    />
+                    <ChecklistItem
+                      title="Brand Kit"
+                      time=""
+                      icon="🎨"
+                      isChecked={checklist.brand}
+                      onToggle={() => toggleChecklist("brand")}
+                    />
+                    <ChecklistItem
+                      title="Pronunciation List"
+                      time=""
+                      icon="🗣️"
+                      isChecked={checklist.pronunciation}
+                      onToggle={() => toggleChecklist("pronunciation")}
+                    />
+                    <ChecklistItem
+                      title="Portraits"
+                      time="1–2 photos"
+                      icon="📸"
+                      isChecked={checklist.portraits}
+                      onToggle={() => toggleChecklist("portraits")}
+                    />
+                  </div>
+                  {allItemsChecked && (
+                    <p className="mt-6 font-semibold text-green-400 text-2xl animate-pulse">
+                      Congratulations! You've completed the checklist.
+                    </p>
+                  )}
+                  <p
+                    className={`mt-6 font-semibold text-cyan-300 ${
+                      allItemsChecked ? "hidden" : "block"
+                    }`}
+                  >
+                    Estimated Time: 30–45 minutes
+                  </p>
+                </GlassPanel>
+              </section>
+
+              <section className="space-y-6">
+                <h2 className="text-3xl font-bold text-center">Upload &amp; Handoff</h2>
+                <GlassPanel className="text-center">
+                  <p className="text-white/80 mb-6">
+                    Use the folder structure provided to organize your files. Click on each folder to check it off as you upload your assets.
+                  </p>
+                  <ul className="space-y-3 text-left">
+                    <FolderChecklistItem
+                      folderName="00_Admin_Consent/"
+                      isChecked={folderChecklist.consent}
+                      onToggle={() => toggleFolderChecklist("consent")}
+                    />
+                    <FolderChecklistItem
+                      folderName="01_Video_Master/"
+                      isChecked={folderChecklist.videoMaster}
+                      onToggle={() => toggleFolderChecklist("videoMaster")}
+                    />
+                    <FolderChecklistItem
+                      folderName="02_Voice_Clips/"
+                      isChecked={folderChecklist.voiceClips}
+                      onToggle={() => toggleFolderChecklist("voiceClips")}
+                    />
+                    <FolderChecklistItem
+                      folderName="03_Portraits/"
+                      isChecked={folderChecklist.portraits}
+                      onToggle={() => toggleFolderChecklist("portraits")}
+                    />
+                    <FolderChecklistItem
+                      folderName="04_Brand_Kit/"
+                      isChecked={folderChecklist.brandKit}
+                      onToggle={() => toggleFolderChecklist("brandKit")}
+                    />
+                    <FolderChecklistItem
+                      folderName="05_Pronunciations/"
+                      isChecked={folderChecklist.pronunciations}
+                      onToggle={() => toggleFolderChecklist("pronunciations")}
+                    />
+                  </ul>
+                  {allFoldersChecked && (
+                    <p className="mt-6 font-semibold text-green-400 text-2xl animate-pulse">
+                      Congratulations! All your folders are ready for training.
+                    </p>
+                  )}
+                </GlassPanel>
+              </section>
+
+              <section className="space-y-6">
+                <h2 className="text-3xl font-bold text-center">Video Capture Guide</h2>
+                <GlassPanel>
+                  <p className="text-white/80 mb-6">
+                    Use a greenscreen (preferred) or your tidy usual setup. Keep the camera at eye level, frame head-and-shoulders, and light your face evenly. Record a single continuous take (~5 minutes).
+                  </p>
+                  <ul className="list-disc list-inside space-y-2 text-white/90">
+                    <li>
+                      <strong>Framing:</strong> Head-and-shoulders, eye-level; both ears visible; look into lens.
+                    </li>
+                    <li>
+                      <strong>Lighting:</strong> Soft, even, front-biased. Avoid mixed color temperatures.
+                    </li>
+                    <li>
+                      <strong>Audio:</strong> Quiet room; AC/fans off. External mic preferred.
+                    </li>
+                    <li>
+                      <strong>Wardrobe:</strong> Record 3–4 looks (mid-tones, avoid tiny patterns).
+                    </li>
+                    <li>
+                      <strong>Delivery:</strong> Speak about a favorite topic (no script). Include your full name and brand terms once.
+                    </li>
+                    <li>
+                      <strong>File naming:</strong> <code>&lt;Brand&gt;_&lt;FullName&gt;_AvatarMaster_take01.mp4</code>
+                    </li>
+                  </ul>
+                </GlassPanel>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <DoDontCard
+                    type="do"
+                    title="Do"
+                    items={[
+                      "Center yourself, keep a steady posture.",
+                      "Slight over-articulation of consonants for clearer mouth shapes."
+                    ]}
+                  />
+                  <DoDontCard
+                    type="dont"
+                    title="Don’t"
+                    items={[
+                      "Mixed color lights, heavy backlight, or flicker.",
+                      "Noisy rooms or active noise suppression that “pumps.”"
+                    ]}
+                  />
+                </div>
+              </section>
+
+              <section className="space-y-6">
+                <h2 className="text-3xl font-bold text-center">Natural Voice Guide</h2>
+                <GlassPanel>
+                  <p className="text-white/80 mb-6">
+                    Record 6–10 clips (30–60s each), in a calm environment with no music. WAV, mono, 44.1/48 kHz.
+                  </p>
+                  <ul className="list-disc list-inside space-y-2 text-white/90">
+                    <li>
+                      <strong>Content:</strong> Natural conversation about familiar topics; include your brand terms.
+                    </li>
+                    <li>
+                      <strong>Technique:</strong> Mic 15–20 cm away, slightly off-axis. Use a pop filter if available.
+                    </li>
+                    <li>
+                      <strong>Levels:</strong> Keep levels peaking around −12 to −6 dB; avoid clipping.
+                    </li>
+                    <li>
+                      <strong>File naming:</strong> <code>&lt;Brand&gt;_&lt;FullName&gt;_VoiceTrain_01.wav</code>
+                    </li>
+                  </ul>
+                </GlassPanel>
+              </section>
+
+              <section className="space-y-6">
+                <h2 className="text-3xl font-bold text-center">Consent Statements</h2>
+                <GlassPanel>
+                  <p className="text-white/80 mb-6">
+                    Record these two short consent statements clearly and simply.
+                  </p>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <GlassPanel className="p-4 space-y-2">
+                      <h3 className="text-xl font-bold">On-camera (video)</h3>
+                      <p className="bg-gray-800/50 p-4 rounded-lg italic border border-white/10 text-sm">
+                        "I, &lt;Full Name&gt;, consent to the capture and use of my likeness to create an AI avatar for &lt;Brand&gt; for approved brand content."
+                      </p>
+                      <p className="text-xs text-white/70">
+                        Save as: <code>&lt;Brand&gt;_&lt;FullName&gt;_Consent_Video.mp4</code>
+                      </p>
+                    </GlassPanel>
+                    <GlassPanel className="p-4 space-y-2">
+                      <h3 className="text-xl font-bold">Audio (voice)</h3>
+                      <p className="bg-gray-800/50 p-4 rounded-lg italic border border-white/10 text-sm">
+                        "I, &lt;Full Name&gt;, consent to the capture and use of my voice to create an AI voice model for &lt;Brand&gt; for approved brand content."
+                      </p>
+                      <p className="text-xs mt-2 text-white/70">
+                        Save as: <code>&lt;Brand&gt;_&lt;FullName&gt;_Consent_Audio.wav</code>
+                      </p>
+                    </GlassPanel>
+                  </div>
+                </GlassPanel>
+              </section>
+
+              <section className="space-y-6">
+                <h2 className="text-3xl font-bold text-center">Brand &amp; Pronunciation Assets</h2>
+                <GlassPanel>
+                  <ul className="list-disc list-inside space-y-3 text-white/90">
+                    <li>
+                      <strong>Brand kit:</strong> Logo (SVG/PNG), primary/secondary colors (hex), typography preferences.
+                    </li>
+                    <li>
+                      <strong>Pronunciation list:</strong> Names, places, acronyms, and special terms.
+                    </li>
+                    <li>
+                      <strong>Portraits:</strong> 1–2 high-res, front-facing images.
+                    </li>
+                  </ul>
+                </GlassPanel>
+              </section>
+
+              <section className="space-y-6">
+                <h2 className="text-3xl font-bold text-center">Support &amp; Expectations</h2>
+                <GlassPanel className="p-8">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 text-center">
+                    <div className="space-y-2">
+                      <div className="text-4xl text-white/80">⏳</div>
+                      <h3 className="font-bold text-lg">Turnaround</h3>
+                      <p className="text-sm text-white/70">
+                        First preview in 3–5 business days after full upload.
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="text-4xl text-white/80">✅</div>
+                      <h3 className="font-bold text-lg">Reshoot Policy</h3>
+                      <p className="text-sm text-white/70">
+                        If criteria aren’t met, we’ll request specific fixes (usually 1–2 quick pickups).
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="text-4xl text-white/80">💬</div>
+                      <h3 className="font-bold text-lg">Contact</h3>
+                      <p className="text-sm text-white/70">
+                        Need help? Message us at support@socialseo.com or start a WhatsApp chat.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="mt-8 text-center">
+                    <a
+                      href="https://wa.me/919315858737?text=Hi%2C%20I%20have%20a%20question%20about%20my%20AI%20avatar%20onboarding."
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-block bg-white/10 backdrop-blur-sm border border-white/20 text-white font-bold py-3 px-8 rounded-full hover:bg-white/20 transition-colors duration-300 shadow-xl"
+                    >
+                      Questions? Chat on WhatsApp
+                    </a>
+                  </div>
+                </GlassPanel>
+              </section>
+            </main>
+          </div>
+        );
+      };
+
+      ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@
             </div>
             <div class="flex items-center space-x-4">
                 <a href="guide2/" class="text-gray-300 hover:text-white text-sm">AI Rap Guide</a>
+                <a href="avatar-guide/" class="text-gray-300 hover:text-white text-sm">Avatar Guide</a>
                 <a href="#content-plan" class="btn-primary text-white font-semibold py-2 px-5 rounded-lg text-sm">
                     See The Plan
                 </a>


### PR DESCRIPTION
## Summary
- add an Avatar Studio onboarding experience as a new React-powered subpage
- reuse reusable glassmorphism components for the new guide with interactive checklists and chatbot fallback handling
- link the new guide from the homepage navigation and README for discoverability

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd99feeed4832b8068513e3b1f2de8