### PR TITLE
Enhance avatar guide panels with liquid glass interaction

### DIFF
--- a/avatar-guide/index.html
+++ b/avatar-guide/index.html
@@ -14,11 +14,67 @@
     <script type="text/babel">
       const { useState, useRef, useEffect } = React;
 
-      const GlassPanel = ({ children, className = "" }) => (
-        <div className={`backdrop-blur-sm bg-black/30 border border-white/10 shadow-lg rounded-2xl p-6 md:p-10 ${className}`}>
-          {children}
-        </div>
-      );
+      const GlassPanel = ({ children, className = "", style = {}, ...rest }) => {
+        const panelRef = useRef(null);
+        const [isHovering, setIsHovering] = useState(false);
+        const [mousePosition, setMousePosition] = useState({ x: 50, y: 50 });
+
+        const updateMousePosition = (event) => {
+          const node = panelRef.current;
+          if (!node) return;
+
+          const rect = node.getBoundingClientRect();
+          const x = ((event.clientX - rect.left) / rect.width) * 100;
+          const y = ((event.clientY - rect.top) / rect.height) * 100;
+
+          setMousePosition({
+            x: Math.min(100, Math.max(0, x)),
+            y: Math.min(100, Math.max(0, y))
+          });
+        };
+
+        const resetMousePosition = () => {
+          setMousePosition({ x: 50, y: 50 });
+          setIsHovering(false);
+        };
+
+        return (
+          <div
+            ref={panelRef}
+            className="relative rounded-3xl transition-transform duration-500"
+            onMouseEnter={(event) => {
+              setIsHovering(true);
+              updateMousePosition(event);
+            }}
+            onMouseMove={updateMousePosition}
+            onMouseLeave={resetMousePosition}
+          >
+            <div
+              className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-90 transition-opacity duration-500"
+              style={{
+                background: `radial-gradient(circle at ${mousePosition.x}% ${mousePosition.y}%, rgba(255,255,255,0.6), rgba(148,163,184,0.12) 38%, rgba(15,23,42,0) 70%), linear-gradient(135deg, rgba(59,130,246,0.35), rgba(236,72,153,0.25))`,
+                filter: `saturate(${isHovering ? 1.4 : 1.2})`,
+                opacity: isHovering ? 1 : 0.85
+              }}
+            />
+            <div
+              {...rest}
+              className={`relative overflow-hidden rounded-[inherit] border border-white/20 bg-white/10 backdrop-blur-2xl shadow-[0_22px_55px_rgba(15,23,42,0.45)] transition-all duration-500 will-change-transform p-6 md:p-10 ${className}`}
+              style={{
+                transform: isHovering ? "translateY(-4px) scale(1.01)" : "translateY(0) scale(1)",
+                background: "linear-gradient(135deg, rgba(15, 23, 42, 0.65), rgba(30, 41, 59, 0.55))",
+                boxShadow: isHovering
+                  ? "0 30px 60px -15px rgba(59, 130, 246, 0.45)"
+                  : "0 20px 45px -15px rgba(15, 23, 42, 0.55)",
+                ...style
+              }}
+            >
+              <div className="pointer-events-none absolute inset-0 rounded-[inherit] border border-white/30 mix-blend-screen opacity-60" />
+              <div className="relative z-10">{children}</div>
+            </div>
+          </div>
+        );
+      };
 
       const DoDontCard = ({ type, title, items }) => {
         const isDo = type === "do";


### PR DESCRIPTION
## Summary
- replace the static GlassPanel styling with a liquid glass inspired treatment that reacts to mouse position
- add hover-driven gradient lighting, blur, and depth transitions to better match the desired aesthetic
- keep panel API compatibility while forwarding extra props so interactive cards continue working

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68cda2aeb9ac832ba9712a14b1b5db50